### PR TITLE
#1 Update site title and tagline in Docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,8 +10,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'My Site',
-  tagline: 'Dinosaurs are cool',
+  title: 'NutriApp',
+  tagline: 'A sua saúde, controlada byte a byte.',
   favicon: 'img/favicon.ico',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -20,10 +20,10 @@ const config = {
   },
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: 'https://github.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/ADC_TP_NUTRICAO/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
This pull request updates the Docusaurus site configuration to reflect branding and deployment changes for the project. The most important changes are grouped below:

Branding updates:

* Changed the site `title` to `'NutriApp'` and updated the `tagline` to `'A sua saúde, controlada byte a byte.'` to better represent the application's purpose.

Deployment configuration:

* Updated the production `url` to `'https://github.com'` and set the `baseUrl` to `'/ADC_TP_NUTRICAO/'` for correct GitHub Pages deployment.