### PR TITLE
Feature/1 configuração metadados do site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'NutriApp',
-  tagline: 'A sua saúde, controlada byte a byte.',
+  tagline: 'A sua saúde, controlada byte a byte',
   favicon: 'img/favicon.ico',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future


### PR DESCRIPTION
This pull request updates the Docusaurus site configuration to reflect new branding and deployment settings for the project. The most important changes are grouped below:

Branding updates:
* Changed the site `title` to "NutriApp" and updated the `tagline` to "A sua saúde, controlada byte a byte" to better represent the project's purpose and audience.

Deployment configuration:
* Updated the production `url` to "https://github.com" and set the `baseUrl` to "/ADC_TP_NUTRICAO/" to match the intended GitHub Pages deployment path.